### PR TITLE
Make RSVP property generate boolean values ("TRUE"/"FALSE")

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,5 +6,6 @@ MANIFEST			This list of files
 README
 t/00-load.t
 t/manifest.t
+t/net-caldavtalk-rsvp.t
 t/pod-coverage.t
 t/pod.t

--- a/lib/Net/CalDAVTalk.pm
+++ b/lib/Net/CalDAVTalk.pm
@@ -2594,7 +2594,9 @@ sub _argsToVEvents {
       next unless grep { $_ eq 'attendee' } @{$Attendee->{roles}};
 
       $AttendeeProps{"CUTYPE"}     = uc $Attendee->{"kind"} if defined $Attendee->{"kind"};
-      $AttendeeProps{"RSVP"}       = uc $Attendee->{"scheduleRSVP"} if defined $Attendee->{"scheduleRSVP"};
+      if( defined $Attendee->{"scheduleRSVP"}) {
+          $AttendeeProps{"RSVP"} = $AttendeeProps{"RSVP"} ? "TRUE" : "FALSE";
+      };
       $AttendeeProps{"X-SEQUENCE"} = $Attendee->{"x-sequence"} if defined $Attendee->{"x-sequence"};
       $AttendeeProps{"X-DTSTAMP"}  = $Self->_makeZTime($Attendee->{"scheduleUpdated"}) if defined $Attendee->{"scheduleUpdated"};
       foreach my $prop (keys %AttendeeProps) {

--- a/t/net-caldavtalk-rsvp.t
+++ b/t/net-caldavtalk-rsvp.t
@@ -1,0 +1,48 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use JSON::PP::Boolean;
+use Net::CalDAVTalk;
+use Data::Dumper;
+
+my $event = {
+          'isAllDay' => bless( do{\(my $o = 0)}, 'JSON::PP::Boolean' ),
+          'participants' => {
+                              'corion@example.com' => {
+                                                                    'name' => 'corion@example.com',
+                                                                    'roles' => [
+                                                                                 'attendee'
+                                                                               ],
+                                                                    'scheduleRSVP' => bless( do{\(my $o = 0)}, 'JSON::PP::Boolean' ),
+                                                                    'kind' => 'individual',
+                                                                    'scheduleStatus' => 'needs-action',
+                                                                    'email' => 'corion@example.com'
+                                                                  },
+                            },
+          'created' => '2019-10-07T12:17:04Z',
+          'title' => 'Example date',
+          'sequence' => 0,
+          'description' => 'RSVP field gets set to "0" instead of "FALSE"',
+          'timeZone' => 'Etc/UTC',
+          'method' => 'REQUEST',
+          'start' => '2019-10-20T15:30:00'
+        };
+
+my $caldavtalk = bless {} => 'Net::CalDAVTalk';
+my $vevent = $caldavtalk->_argsToVCalendar( $event );
+
+my $entry = $vevent->entries->[0];
+my $attendee = $entry->property('attendee')->[0];
+my $rsvp = $attendee->parameters->{'RSVP'};
+
+is $rsvp, "FALSE", "We encode the RSVP property as 'FALSE' in the data structure"
+    or diag Dumper $rsvp;
+
+my $vevent_str = $vevent->as_string();
+
+$vevent_str =~ qr/\bRSVP\s*=([^:]+)\b/;
+my $rsvp_value = $1;
+like $rsvp_value, qr/^(TRUE|FALSE)$/, "and the RSVP property is TRUE or FALSE in the vevent string too"
+    or diag $vevent_str;


### PR DESCRIPTION
The RSVP property gets converted to JSON::PP::Boolean values internally
but these do not get converted back when creating the Data::ICal data structure
or the VCALENDAR string.

This patch fixes that and adds a unit test for the behaviour.